### PR TITLE
fixed heading bug

### DIFF
--- a/lib/lawnmower.js
+++ b/lib/lawnmower.js
@@ -5,7 +5,7 @@ GRASSIST.lawnmower = function(yard) {
   var HEADINGS = ['east', 'north', 'west', 'south'];
   var LONGITUDE_STEPS = [1, 0, -1, 0], LATITUDE_STEPS = [0, 1, 0, -1];
 
-  var heading = EAST;
+  var current_heading = EAST;
   var longitude = 0, latitude = 0;
   var rotorEnabled = false;
 
@@ -24,17 +24,17 @@ GRASSIST.lawnmower = function(yard) {
   };
 
   var moveForward = function() {
-    longitude = longitude + LONGITUDE_STEPS[heading];
-    latitude = latitude + LATITUDE_STEPS[heading];
+    longitude = longitude + LONGITUDE_STEPS[current_heading];
+    latitude = latitude + LATITUDE_STEPS[current_heading];
     process();
   };
 
   var turnLeft = function() {
-    heading = (heading + 1) % 4;
+    current_heading = (current_heading + 1) % 4;
   };
 
   var turnRight = function() {
-    heading = (heading + 3) % 4;
+    current_heading = (current_heading + 3) % 4;
   };
 
   var position = function() {
@@ -42,7 +42,7 @@ GRASSIST.lawnmower = function(yard) {
   };
 
   var heading = function() {
-    return HEADINGS[heading];
+    return HEADINGS[current_heading];
   };
 
   var rotorEnabled = function() {


### PR DESCRIPTION
The heading variable that stores the current heading in the lawnmower class was overwritten by the heading function which returns the string of the current direction.  I didn't change the lawnmower API at all, but simply changed the heading variable to current_heading so that they don't collide anymore.

current_heading seemed like a logical name! plus you don't need to mess with the README or anything to update documentation. 
