### PR TITLE
Fix missing first segment of trail in visualization.

### DIFF
--- a/lib/lawnmower.js
+++ b/lib/lawnmower.js
@@ -12,6 +12,7 @@ GRASSIST.lawnmower = function(homeLongitude, homeLatitude) {
   var callbacks = [];
 
   var onUpdate = function(callback) {
+    callback(that);
     callbacks.push(callback);
   };
 


### PR DESCRIPTION
Call update callbacks with the initial state, fixing a visualizer bug where the first segment was not shown if the lawnmower moved forward before doing anything else.